### PR TITLE
Add working examples for mac

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,7 @@ services:
     haproxy:
         image: haproxy
         container_name: haproxy-proxy
-        # network_mode: "host" is required when running on Linux hosts.
-        network_mode: "host"
+        network_mode: "host" # Required when running on Linux hosts. Don't run wit it on Mac.
         ports:
             - 443:443
             - 80:80

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -21,13 +21,23 @@ frontend https
     redirect scheme https code 301 if !{ ssl_fc }
 
     # Add one acl and use_backend per domain
+    # These will work for Linux
     acl host_whicheloe.us hdr(host) -i whicheloe.us
     use_backend whicheloe.us if host_whicheloe.us
-    
+
     acl host_example.org hdr(host) -i example.org
     use_backend example.org if host_example.org
 
+    # # Mac variants
+    # acl host_whicheloe.us hdr(host) -i whicheloe.us
+    # use_backend whicheloe.us if host_whicheloe.us
+
+    # # The localhost variant might be useful for local dev using certs with your hosts pointing it at localhost
+    # acl host_localhost.example.org hdr(host) -i localhost.example.org
+    # use_backend localhost.example.org if host_localhost.example.org
+
 # Back Ends
+# Linux versions
 backend whicheloe.us
     option forwardfor
     server localhost localhost:3005 check
@@ -35,3 +45,13 @@ backend whicheloe.us
 backend example.org
     option forwardfor
     server localhost localhost:3006 check
+
+# # Mac varsions
+# backend whicheloe.us
+#     option forwardfor
+#     server host.docker.internal host.docker.internal:3005 check
+
+# # Including localhost variant
+# backend localhost.example.org
+#     option forwardfor
+#     server host.docker.internal host.docker.internal:3006 check

--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,11 @@
 # Example HAProxy setup to reverse proxy multiple domains
-This setup uses a docker to setup HAProxy.<br>
+This uses a docker container to setup HAProxy.<br>
 The dockerized instance binds ports 80 and 443 on the host.<br>
 This setup uses Http2 and http->https redirection via a 301 for all domains.<br>
 
 ## Configuring
 The dockerized instance mounts a file, haproxy.cfg, and a folder ./certs.<br>
-To add a new domain, create a new Access Control List (acl) and use_backend config in the frontend section.<br>
+To add a new domain, add to the config a new Access Control List (acl) and use_backend config in the frontend section.<br>
 ```
 acl host_example.org hdr(host) -i example.org
 use_backend example.org if host_example.org
@@ -16,15 +16,16 @@ backend example.org
     option forwardfor
     server localhost localhost:3005 check
 ```
-And add a pem file to ./certs.<br>
-HAProxy uses a single pem file containing the full chain and private key.<br>
+And add a pem file to ./certs.<br><!-- FYI two spaces here will do the same thing as the br. I sorta like it explicit -->
+HAProxy uses a single pem file containing the full chain and private key (order seems to be ambiguous).<br>
 <br>
 Any files other than valid certificates in ./certs will cause HAProxy to error.<br>
 This is why there is no certs folder included with this project as I couldn't include a .gitkeep.<br>
 
 ## Running on non-linux
-As is, this setup will only work on linux hosts.<br>
-This is because the dockerized HAproxy uses network mode "host".<br>
-This makes it simple to proxy to port on the machine, but isn't supported when running on non-linux.<br>
-In order to run on non-linux, disable the line ```network_mode: "host"``` in the docker-compose.yml.<br>
-Additionally, in the haproxy.cfg, change instances of localhost for host.docker.internal.
+Comments in both files contain working examples for Mac.<br>
+The docker-compose uses `network mode: "host"`.<br>
+This makes it simple to proxy to a port on the machine, but isn't supported when running on non-linux.<br>
+
+In order to run on non-linux, disable the line `network_mode: "host"` in the docker-compose.yml.<br>
+Additionally, in the haproxy.cfg, in the `backend` section, change all instances of `localhost` to `host.docker.internal`.


### PR DESCRIPTION
I think improved readability for dunderheads like myself slightly. Ported the working examples I have in my own hap config for mac. Now you can comment switch a few lines in each file and it'll work for either.